### PR TITLE
SHO-86: Custom Data

### DIFF
--- a/app/components/templates/regulars-info/regulars-info.component.tsx
+++ b/app/components/templates/regulars-info/regulars-info.component.tsx
@@ -1,3 +1,5 @@
+import {FC} from 'react';
+
 import {
   BlockDivider,
   Grid,
@@ -11,21 +13,32 @@ import {Divider} from '../../atoms/divider';
 import {Paragraph} from '../../atoms/paragraph';
 import {Subtitle} from '../../molecules/subtitle';
 
-const {regularsInfo, regularsDisclaimer} = configData;
+const {regularsDisclaimer} = configData;
 
-export const RegularsInfo = () => {
+export interface RegularsInfoBlock {
+  index?: string;
+  title?: string;
+  body?: string;
+  footer?: string;
+}
+
+interface Props {
+  infoBlocks: RegularsInfoBlock[];
+}
+
+export const RegularsInfo: FC<Props> = ({infoBlocks}) => {
   const isDesktop = useMediaQuery('(min-width: 768px)');
 
   return (
     <InfoSection>
       <Grid>
-        {regularsInfo.map((info, index, arr) => {
+        {infoBlocks.map((info, index, arr) => {
           const renderBlockDivider = isDesktop
             ? index < arr.length - (2 - (arr.length % 2))
             : index < arr.length - 1;
 
           return (
-            <InfoBlock key={info.id}>
+            <InfoBlock key={info.title}>
               <Subtitle numeral={`${index + 1}.`}>{info.title}</Subtitle>
               <Paragraph>{info.body}</Paragraph>
               <Paragraph bold>{info.footer}</Paragraph>

--- a/app/config.json
+++ b/app/config.json
@@ -88,31 +88,5 @@
     "title": "Programa de Clientes Frecuentes",
     "description": "Conoce nuestro programa de recompensas, creado para premiarte por tu consumo."
   },
-  "regularsInfo": [
-    {
-      "id": "f43ecfd4-bb76-4960-8e5d-0ca1c8a559b0",
-      "title": "Lorem ipsum",
-      "body": "Lorem ipsum dolor sit amet, conctetuer adipiscing elitvolutpat. Hendrerit in vulputatevelit esse. Utwisi enim ad minimveniam.",
-      "footer": "Molestie consequat, vel illum dolore eu feugiat."
-    },
-    {
-      "id": "3cb03792-5b8e-4789-ba84-0996717b50d3",
-      "title": "Lorem ipsum",
-      "body": "Lorem ipsum dolor sit amet, conctetuer adipiscing elitvolutpat. Hendrerit in vulputatevelit esse. Utwisi enim ad minimveniam.",
-      "footer": "Molestie consequat, vel illum dolore eu feugiat."
-    },
-    {
-      "id": "ea89c606-fd46-4f70-9b24-18228e7ebdd3",
-      "title": "Lorem ipsum",
-      "body": "Lorem ipsum dolor sit amet, conctetuer adipiscing elitvolutpat. Hendrerit in vulputatevelit esse. Utwisi enim ad minimveniam.",
-      "footer": "Molestie consequat, vel illum dolore eu feugiat."
-    },
-    {
-      "id": "5b1460c6-6ce7-4abc-a0f1-38f9392778c2",
-      "title": "Lorem ipsum",
-      "body": "Lorem ipsum dolor sit amet, conctetuer adipiscing elitvolutpat. Hendrerit in vulputatevelit esse. Utwisi enim ad minimveniam.",
-      "footer": "Molestie consequat, vel illum dolore eu feugiat."
-    }
-  ],
   "regularsDisclaimer": "*Aplican restricciones. No válido con otras promociones. Los sellos son intransferibles. Las recompensas no pueden ser cobradas en efectivo. Recompensas sujetas a existencias. El programa de recompensas puede ser negado a discreción si se considera que se está haciendo mal uso de la misma."
 }

--- a/app/routes/frecuentes.tsx
+++ b/app/routes/frecuentes.tsx
@@ -1,27 +1,79 @@
-import {Link} from '@remix-run/react';
+import {Link, useLoaderData} from '@remix-run/react';
+import {
+  Metaobject,
+  MetaobjectField,
+} from '@shopify/hydrogen/storefront-api-types';
+import {LoaderArgs, json} from '@shopify/remix-oxygen';
 
 import {NavBar, NavBarLink} from '~/components/organisms/navbar';
 import {RegularsHero} from '~/components/organisms/regulars-hero/regulars-hero.component';
 import {Footer} from '~/components/templates/footer';
-import {RegularsInfo} from '~/components/templates/regulars-info';
+import {
+  RegularsInfo,
+  RegularsInfoBlock,
+} from '~/components/templates/regulars-info';
 import configData from '~/config.json';
+
+type ReducedMetafield = Record<keyof RegularsInfoBlock, string | undefined>;
+
+export async function loader({context: {storefront}}: LoaderArgs) {
+  const {metaobjects} = await storefront.query<Array<Metaobject>>(
+    METAOBJECTS_QUERY,
+  );
+
+  return json({metaobjects});
+}
 
 // @ts-ignore
 const _Link = (props) => <NavBarLink {...props} as={Link} />;
 
 export default function Frecuentes() {
+  const {
+    metaobjects: {nodes: metaobjectNodes},
+  } = useLoaderData<typeof loader>();
+
   const links = configData.navbar.links.map((link) => ({
     label: link.label,
     href: link.link,
     ...(link.label === 'Frecuentes' && {active: 'true'}),
   }));
 
+  const infoBlocks = (metaobjectNodes as Array<Metaobject>)
+    .map<RegularsInfoBlock>((metaobject) => {
+      const fields = metaobject.fields.reduce(
+        (result: ReducedMetafield, {key, value}) => {
+          result[key as keyof RegularsInfoBlock] = value ?? '';
+
+          return result;
+        },
+        {} as ReducedMetafield,
+      );
+
+      return fields;
+    })
+    .sort(({index: indexA}, {index: indexB}) => +indexA! - +indexB!);
+
   return (
     <>
       <NavBar links={links} linkRender={_Link} />
       <RegularsHero />
-      <RegularsInfo />
+      <RegularsInfo infoBlocks={infoBlocks} />
       <Footer />
     </>
   );
 }
+
+const METAOBJECTS_QUERY = `#graphql
+  query MetaObjects {
+    metaobjects(first: 4, type: "regulars_info") {
+      nodes {
+        id,
+        type,
+        fields {
+          key,
+          value
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
## Describe your changes

This PR adds a query to Shopify's Metaobjects which are then displayed on the `/frecuentes` page.

## Task URL (Asana, Jira, etc...)

[SHO-86](https://cultoperrocafe.nifty.pm/l/EtP!ZtLwy9o4o)

## What was done in this pull request

- [x] Created a GraphQL query which gets the first 4 metaobjects of type `regulars_info`.
- [x] Refactored `regulars-info.component.tsx` to receive a prop with a list of objects to render.
- [x] Removed the hardcoded data from `config.json`.

## Demo / Screenshot / Video

![image](https://github.com/tepachelabs/perro-cafe-storefront/assets/39208827/f92fe99a-9b15-4350-989f-1a8e431116db)
