### PR TITLE
Add font load to links function

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -29,7 +29,19 @@ export const links: LinksFunction = () => {
       rel: 'preconnect',
       href: 'https://shop.app',
     },
+    {
+      rel: 'preconnect',
+      href: 'https://fonts.googleapis.com',
+    },
+    {
+      rel: 'preconnect',
+      href: 'https://fonts.gstatic.com',
+    },
     {rel: 'icon', type: 'image/svg+xml', href: favicon},
+    {
+      rel: 'stylesheet',
+      href: 'https://fonts.googleapis.com/css2?family=Oswald:wght@400;700&family=Raleway:wght@400;700&display=swap',
+    },
   ];
 };
 


### PR DESCRIPTION
## Describe your changes

This PR adds font loading from Google Fonts.
While researching on this topic, I didn't really find a specific way to load fonts on Remix (like, for example, `next/font` on NextJS), and instead  I found [this article](https://remix.run/docs/en/1.16.1/guides/migrating-react-router-app#asset-imports) about migrating a React Router app to Remix, stating that we can use the `LinksFunction` just like we'd use a `<link>` element.

## Task URL (Asana, Jira, etc...)

[SHO-87](https://cultoperrocafe.nifty.pm/l/neA7mlFd0!0N_)

## What was done in this pull request

- [x] Added font links to `LinksFunction` on `root.tsx` so they're available on all of the pages.

## Demo / Screenshot / Video

![image](https://github.com/tepachelabs/perro-cafe-storefront/assets/39208827/50194789-f527-4c05-85b4-3571bc98792c)
