### PR TITLE
Regulars Page

### DIFF
--- a/app/components/organisms/regulars-hero/index.ts
+++ b/app/components/organisms/regulars-hero/index.ts
@@ -1,0 +1,1 @@
+export * from './regulars-hero.component';

--- a/app/components/organisms/regulars-hero/regulars-hero.component.tsx
+++ b/app/components/organisms/regulars-hero/regulars-hero.component.tsx
@@ -1,3 +1,5 @@
+import {FC} from 'react';
+
 import banner from './img/regular-clients-banner.svg';
 import {
   Description,
@@ -7,16 +9,25 @@ import {
   RegularsTitle,
   SecondaryContainer,
 } from './regulars-hero.styles';
-import configData from '../../../config.json';
 
-export const RegularsHero = () => (
+interface Subtitle {
+  value: string;
+}
+
+interface Props {
+  title: string;
+  subtitle?: Subtitle;
+  imgSrc?: string;
+}
+
+export const RegularsHero: FC<Props> = ({title, subtitle, imgSrc}) => (
   <RegularsHeroContainer>
     <PrimaryContainer>
-      <RegularsTitle>{configData.regularsHero.title}</RegularsTitle>
-      <Description bold>{configData.regularsHero.description}</Description>
+      <RegularsTitle>{title}</RegularsTitle>
+      {subtitle && <Description bold>{subtitle.value}</Description>}
     </PrimaryContainer>
     <SecondaryContainer>
-      <RegularsHeroBanner src={banner} alt="Fondo de cabecera" />
+      <RegularsHeroBanner src={imgSrc || banner} alt="Fondo de cabecera" />
     </SecondaryContainer>
   </RegularsHeroContainer>
 );

--- a/app/components/organisms/regulars-hero/regulars-hero.styles.tsx
+++ b/app/components/organisms/regulars-hero/regulars-hero.styles.tsx
@@ -22,6 +22,7 @@ export const PrimaryContainer = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
 
   background-color: transparent;
   border-bottom: ${borderStyle};

--- a/app/components/templates/regulars-info/regulars-info.component.tsx
+++ b/app/components/templates/regulars-info/regulars-info.component.tsx
@@ -1,43 +1,23 @@
-import {
-  BlockDivider,
-  Grid,
-  InfoBlock,
-  InfoSection,
-  SectionDividerContainer,
-} from './regulars-info.styles';
+import parse from 'html-react-parser';
+import {FC} from 'react';
+
+import {InfoSection, SectionDividerContainer} from './regulars-info.styles';
 import configData from '../../../config.json';
-import useMediaQuery from '../../../hooks/use-media-query';
 import {Divider} from '../../atoms/divider';
 import {Paragraph} from '../../atoms/paragraph';
-import {Subtitle} from '../../molecules/subtitle';
 
-const {regularsInfo, regularsDisclaimer} = configData;
+const {regularsDisclaimer} = configData;
 
-export const RegularsInfo = () => {
-  const isDesktop = useMediaQuery('(min-width: 768px)');
+interface Props {
+  content: string;
+}
 
-  return (
-    <InfoSection>
-      <Grid>
-        {regularsInfo.map((info, index, arr) => {
-          const renderBlockDivider = isDesktop
-            ? index < arr.length - (2 - (arr.length % 2))
-            : index < arr.length - 1;
-
-          return (
-            <InfoBlock key={info.id}>
-              <Subtitle numeral={`${index + 1}.`}>{info.title}</Subtitle>
-              <Paragraph>{info.body}</Paragraph>
-              <Paragraph bold>{info.footer}</Paragraph>
-              {renderBlockDivider && <BlockDivider />}
-            </InfoBlock>
-          );
-        })}
-      </Grid>
-      <SectionDividerContainer>
-        <Divider />
-      </SectionDividerContainer>
-      <Paragraph>{regularsDisclaimer}</Paragraph>
-    </InfoSection>
-  );
-};
+export const RegularsInfo: FC<Props> = ({content}) => (
+  <InfoSection>
+    {parse(content)}
+    <SectionDividerContainer>
+      <Divider />
+    </SectionDividerContainer>
+    <Paragraph>{regularsDisclaimer}</Paragraph>
+  </InfoSection>
+);

--- a/app/components/templates/regulars-info/regulars-info.styles.tsx
+++ b/app/components/templates/regulars-info/regulars-info.styles.tsx
@@ -6,9 +6,20 @@ export const InfoSection = styled.section`
   max-width: ${({theme}) => theme.sizes.maxWidth};
   margin: 1rem auto;
   padding: 1rem;
+  color: ${({theme}) => theme.colors.black};
 
   & hr {
     margin: 1.5rem 0;
+  }
+
+  & h2 {
+    font-size: ${({theme}) => theme.sizes.subHeader};
+    font-family: ${({theme}) => theme.fonts.title};
+    font-weight: normal;
+  }
+
+  & p {
+    font-family: ${({theme}) => theme.fonts.body};
   }
 `;
 

--- a/app/routes/frecuentes.tsx
+++ b/app/routes/frecuentes.tsx
@@ -1,15 +1,32 @@
-import {Link} from '@remix-run/react';
+import {Link, useLoaderData} from '@remix-run/react';
+import {Image, Page} from '@shopify/hydrogen/storefront-api-types';
+import {LoaderArgs, json} from '@shopify/remix-oxygen';
 
 import {NavBar, NavBarLink} from '~/components/organisms/navbar';
-import {RegularsHero} from '~/components/organisms/regulars-hero/regulars-hero.component';
+import {RegularsHero} from '~/components/organisms/regulars-hero';
 import {Footer} from '~/components/templates/footer';
 import {RegularsInfo} from '~/components/templates/regulars-info';
 import configData from '~/config.json';
+
+export async function loader({context: {storefront}}: LoaderArgs) {
+  const {page} = await storefront.query<Page>(PAGE_QUERY);
+  const {
+    node: {image},
+  } = await storefront.query<Node>(IMAGE_QUERY, {
+    variables: {
+      id: page.image.value,
+    },
+  });
+
+  return json({page, image});
+}
 
 // @ts-ignore
 const _Link = (props) => <NavBarLink {...props} as={Link} />;
 
 export default function Frecuentes() {
+  const {page, image} = useLoaderData<typeof loader>();
+
   const links = configData.navbar.links.map((link) => ({
     label: link.label,
     href: link.link,
@@ -19,9 +36,40 @@ export default function Frecuentes() {
   return (
     <>
       <NavBar links={links} linkRender={_Link} />
-      <RegularsHero />
-      <RegularsInfo />
+      <RegularsHero
+        title={page.title}
+        subtitle={page.subtitle}
+        imgSrc={(image as Image).url}
+      />
+      <RegularsInfo content={page.body} />
       <Footer />
     </>
   );
 }
+
+const PAGE_QUERY = `#graphql
+  query Pages {
+    page(handle: "frecuentes") {
+      title
+      body
+      image: metafield(namespace: "custom", key: "header_image") {
+        value
+      }
+      subtitle: metafield(namespace: "custom", key: "subtitle") {
+        value
+      }
+    }
+  }
+`;
+
+const IMAGE_QUERY = `#graphql
+  query Image($id: ID!) {
+    node(id: $id) {
+      ... on MediaImage {
+        image {
+          url
+        }
+      }
+    }
+  }
+`;

--- a/app/routes/frecuentes.tsx
+++ b/app/routes/frecuentes.tsx
@@ -48,7 +48,7 @@ export default function Frecuentes() {
 }
 
 const PAGE_QUERY = `#graphql
-  query Pages {
+  query Page {
     page(handle: "frecuentes") {
       title
       body

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@shopify/remix-oxygen": "^1.0.5",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
+        "html-react-parser": "^3.0.16",
         "isbot": "^3.6.6",
         "posthog-js": "^1.57.3",
         "react": "^18.2.0",
@@ -17882,7 +17883,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -22011,6 +22011,84 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/html-dom-parser": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-3.1.7.tgz",
+      "integrity": "sha512-cDgNF4YgF6J3H+d9mcldGL19p0GzVdS3iGuDNzYWQpU47q3+IRM85X3Xo07E+nntF4ek4s78A9V24EwxlPTjig==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "8.0.2"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
@@ -22051,6 +22129,34 @@
       "dev": true,
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-3.0.16.tgz",
+      "integrity": "sha512-ysQZtRFPcg+McVb4B05oNWSnqM14zagpvTgGcI5e1/BvCl38YwzWzKibrbBmXeemg70olN1bAoeixo7o06G5Eg==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "3.1.7",
+        "react-property": "2.0.0",
+        "style-to-js": "1.1.3"
+      },
+      "peerDependencies": {
+        "react": "0.14 || 15 || 16 || 17 || 18"
+      }
+    },
+    "node_modules/html-react-parser/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/html-tags": {
@@ -29178,6 +29284,11 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/react-property": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
+      "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
+    },
     "node_modules/react-reconciler": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.0.tgz",
@@ -32283,6 +32394,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.3.tgz",
+      "integrity": "sha512-zKI5gN/zb7LS/Vm0eUwjmjrXWw8IMtyA8aPBJZdYiQTXj4+wQ3IucOLIOnF7zCHxvW8UhIGh/uZh/t9zEHXNTQ==",
+      "dependencies": {
+        "style-to-object": "0.4.1"
+      }
+    },
+    "node_modules/style-to-js/node_modules/style-to-object": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz",
+      "integrity": "sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==",
+      "dependencies": {
+        "inline-style-parser": "0.1.1"
       }
     },
     "node_modules/style-to-object": {
@@ -48790,8 +48917,7 @@
     "domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
     },
     "domhandler": {
       "version": "4.3.1",
@@ -51975,6 +52101,61 @@
         }
       }
     },
+    "html-dom-parser": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-3.1.7.tgz",
+      "integrity": "sha512-cDgNF4YgF6J3H+d9mcldGL19p0GzVdS3iGuDNzYWQpU47q3+IRM85X3Xo07E+nntF4ek4s78A9V24EwxlPTjig==",
+      "requires": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "8.0.2"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.2",
+            "entities": "^4.2.0"
+          }
+        },
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        },
+        "domutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+          "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+          "requires": {
+            "dom-serializer": "^2.0.0",
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.3"
+          }
+        },
+        "entities": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+        },
+        "htmlparser2": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+          "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.3",
+            "domutils": "^3.0.1",
+            "entities": "^4.4.0"
+          }
+        }
+      }
+    },
     "html-entities": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
@@ -52007,6 +52188,27 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
           "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
           "dev": true
+        }
+      }
+    },
+    "html-react-parser": {
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-3.0.16.tgz",
+      "integrity": "sha512-ysQZtRFPcg+McVb4B05oNWSnqM14zagpvTgGcI5e1/BvCl38YwzWzKibrbBmXeemg70olN1bAoeixo7o06G5Eg==",
+      "requires": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "3.1.7",
+        "react-property": "2.0.0",
+        "style-to-js": "1.1.3"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
         }
       }
     },
@@ -57187,6 +57389,11 @@
       "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==",
       "dev": true
     },
+    "react-property": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
+      "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
+    },
     "react-reconciler": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.0.tgz",
@@ -59601,6 +59808,24 @@
             "@types/json-schema": "^7.0.5",
             "ajv": "^6.12.4",
             "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
+    "style-to-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.3.tgz",
+      "integrity": "sha512-zKI5gN/zb7LS/Vm0eUwjmjrXWw8IMtyA8aPBJZdYiQTXj4+wQ3IucOLIOnF7zCHxvW8UhIGh/uZh/t9zEHXNTQ==",
+      "requires": {
+        "style-to-object": "0.4.1"
+      },
+      "dependencies": {
+        "style-to-object": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz",
+          "integrity": "sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==",
+          "requires": {
+            "inline-style-parser": "0.1.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@shopify/remix-oxygen": "^1.0.5",
     "graphql": "^16.6.0",
     "graphql-tag": "^2.12.6",
+    "html-react-parser": "^3.0.16",
     "isbot": "^3.6.6",
     "posthog-js": "^1.57.3",
     "react": "^18.2.0",


### PR DESCRIPTION
## Describe your changes

This PR refactors `frecuentes.tsx` to get its content from Shopify. Created a query that gets the `frecuentes` Page from Shopify along with two metafields: `header_image` and `subtitle`. The data is then passed to the page's components through props.
For the page's body, I found that there were [two ways](https://medium.com/@uigalaxy7/how-to-render-html-in-react-7f3c73f5cafc) of rendering it. I think using `html-react-parser` looks cleaner and can be more convenient due to the possibility of providing parsing options, so that's what I chose.

## Task URL (Asana, Jira, etc...)

## What was done in this pull request

- [x] Added a specific query for the `frecuentes` Page on Shopify.
- [x] Added a dynamic query for the header banner.
- [x] Refactored `regulars-hero` to expect a title, and an optional subtitle and image URL.
- [x] Refactored `regulars-info` to expect a content prop.
- [x] Added `html-react-parser` to render the content as valid HTML.

## Demo / Screenshot / Video

![image](https://github.com/tepachelabs/perro-cafe-storefront/assets/39208827/599421e7-bf6e-4145-b660-676949e155f4)
All of the texts and the banner in this screenshot are obtained from Shopify.
