### PR TITLE
Shopify menu

### DIFF
--- a/app/components/atoms/link/index.ts
+++ b/app/components/atoms/link/index.ts
@@ -1,0 +1,1 @@
+export * from './link.component';

--- a/app/components/atoms/link/link.component.tsx
+++ b/app/components/atoms/link/link.component.tsx
@@ -1,20 +1,38 @@
-import {Link as RemixLink} from '@remix-run/react';
 import {FC, ReactNode} from 'react';
+
+import {CustomLink} from './link.styles';
+
+export {CustomLink} from './link.styles';
 
 interface Props {
   to: string;
   children: ReactNode;
+  active?: boolean | string;
+  linkRender: FC<{
+    to: string;
+    children: ReactNode;
+    active?: boolean | string;
+  }>;
 }
 
-export const Link: FC<Props> = ({to, children}) => {
+export const Link: FC<Props> = ({
+  to,
+  children,
+  active,
+  linkRender: LinkRender,
+}) => {
   const isExternalLink = to.startsWith('http');
   if (isExternalLink) {
     return (
-      <a href={to} target="_blank" rel="noopener noreferrer">
+      <CustomLink href={to} target="_blank" rel="noopener noreferrer">
         {children}
-      </a>
+      </CustomLink>
     );
   }
 
-  return <RemixLink to={to}>{children}</RemixLink>;
+  return (
+    <LinkRender to={to} active={active}>
+      {children}
+    </LinkRender>
+  );
 };

--- a/app/components/atoms/link/link.component.tsx
+++ b/app/components/atoms/link/link.component.tsx
@@ -1,0 +1,20 @@
+import {Link as RemixLink} from '@remix-run/react';
+import {FC, ReactNode} from 'react';
+
+interface Props {
+  to: string;
+  children: ReactNode;
+}
+
+export const Link: FC<Props> = ({to, children}) => {
+  const isExternalLink = to.startsWith('http');
+  if (isExternalLink) {
+    return (
+      <a href={to} target="_blank" rel="noopener noreferrer">
+        {children}
+      </a>
+    );
+  }
+
+  return <RemixLink to={to}>{children}</RemixLink>;
+};

--- a/app/components/atoms/link/link.stories.tsx
+++ b/app/components/atoms/link/link.stories.tsx
@@ -1,0 +1,17 @@
+import {ComponentMeta, ComponentStory} from '@storybook/react';
+
+import {CustomLink, Link} from './link.component';
+
+export default {
+  title: 'Atoms/Link',
+  component: Link,
+} as ComponentMeta<typeof Link>;
+
+const Template: ComponentStory<typeof Link> = (args) => <Link {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  to: 'https://perro.cafe',
+  children: <p>Culto al Perro Café</p>,
+  linkRender: (props) => <CustomLink {...props} />,
+};

--- a/app/components/atoms/link/link.styles.tsx
+++ b/app/components/atoms/link/link.styles.tsx
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled';
+
+interface NavBarLinkProps {
+  active?: boolean | string;
+}
+
+export const CustomLink = styled.a<NavBarLinkProps>`
+  display: block;
+  padding: 0.5rem 0 0;
+  cursor: pointer;
+  height: 48px;
+
+  color: ${({theme}) => theme.colors.backgroundDarker};
+  font-family: ${({theme}) => theme.fonts.body};
+  font-weight: bold;
+  text-decoration: none;
+  line-height: 48px;
+
+  border-bottom: ${({theme}) => theme.sizes.borderWidth} solid transparent;
+
+  ${(props) => props.theme.mediaQueries.desktop} {
+    display: inline-block;
+    margin-left: 0.65rem;
+    padding: 0;
+    height: auto;
+
+    font-size: 14px;
+    line-height: 16px;
+  }
+
+  ${({theme, active}) =>
+    active && `border-bottom-color: ${theme.colors.primary};`};
+`;

--- a/app/components/molecules/promotion-card/promotion-card.styles.tsx
+++ b/app/components/molecules/promotion-card/promotion-card.styles.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 
-import {select} from '~/utils';
-
+import {select} from '../../../utils';
 import {Paragraph} from '../../atoms/paragraph';
 
 export interface CardProps {

--- a/app/components/organisms/navbar/navbar.component.tsx
+++ b/app/components/organisms/navbar/navbar.component.tsx
@@ -6,8 +6,6 @@ import {MenuButton, Drawer, Flex, _NavBar, Img, Icon} from './navbar.styles';
 import useMediaQuery from '../../../hooks/use-media-query';
 import {Link} from '../../atoms/link';
 
-export {NavBarLink} from './navbar.styles';
-
 interface Props {
   links: Array<{
     label: string;

--- a/app/components/organisms/navbar/navbar.component.tsx
+++ b/app/components/organisms/navbar/navbar.component.tsx
@@ -4,6 +4,7 @@ import burgerMenu from './img/burger-menu.svg';
 import logo from './img/logo.svg';
 import {MenuButton, Drawer, Flex, _NavBar, Img, Icon} from './navbar.styles';
 import useMediaQuery from '../../../hooks/use-media-query';
+import {Link} from '../../atoms/link';
 
 export {NavBarLink} from './navbar.styles';
 
@@ -26,7 +27,7 @@ export const NavBar: FC<Props> = (props) => {
   return isDesktop ? <DesktopNavBar {...props} /> : <MobileNavBar {...props} />;
 };
 
-const MobileNavBar: FC<Props> = ({linkRender: Link, links}) => {
+const MobileNavBar: FC<Props> = ({linkRender: LinkRender, links}) => {
   const [showDrawer, setShowDrawer] = useState(false);
 
   const handleMenuPressed = () => {
@@ -43,7 +44,12 @@ const MobileNavBar: FC<Props> = ({linkRender: Link, links}) => {
       </Flex>
       <Drawer collapsed={!showDrawer}>
         {links.map((link) => (
-          <Link key={link.label} to={link.href} active={link.active}>
+          <Link
+            key={link.label}
+            to={link.href}
+            active={link.active}
+            linkRender={LinkRender}
+          >
             {link.label}
           </Link>
         ))}
@@ -52,13 +58,18 @@ const MobileNavBar: FC<Props> = ({linkRender: Link, links}) => {
   );
 };
 
-const DesktopNavBar: FC<Props> = ({linkRender: Link, links}) => (
+const DesktopNavBar: FC<Props> = ({linkRender: LinkRender, links}) => (
   <_NavBar>
     <Flex>
       <Img src={logo} alt="Logotipo de Culto al Perro Café" />
       <Drawer>
         {links.map((link) => (
-          <Link key={link.label} to={link.href} active={link.active}>
+          <Link
+            key={link.label}
+            to={link.href}
+            active={link.active}
+            linkRender={LinkRender}
+          >
             {link.label}
           </Link>
         ))}

--- a/app/components/organisms/navbar/navbar.stories.tsx
+++ b/app/components/organisms/navbar/navbar.stories.tsx
@@ -1,7 +1,8 @@
 import {ComponentMeta, ComponentStory} from '@storybook/react';
 
-import {NavBar, NavBarLink} from './navbar.component';
+import {NavBar} from './navbar.component';
 import configData from '../../../config.json';
+import {CustomLink} from '../../atoms/link';
 
 export default {
   title: 'Organisms/NavBar',
@@ -17,5 +18,5 @@ Default.args = {
     href: link.link,
     active: index === 0,
   })),
-  linkRender: (props) => <NavBarLink {...props} />,
+  linkRender: (props) => <CustomLink {...props} />,
 };

--- a/app/components/organisms/navbar/navbar.styles.tsx
+++ b/app/components/organisms/navbar/navbar.styles.tsx
@@ -63,31 +63,3 @@ export const Drawer = styled.div<{collapsed?: boolean}>`
     width: auto;
   }
 `;
-
-export const NavBarLink = styled.a<NavBarLinkProps>`
-  display: block;
-  padding: 0.5rem 0 0;
-  cursor: pointer;
-  height: 48px;
-
-  color: ${({theme}) => theme.colors.backgroundDarker};
-  font-family: ${({theme}) => theme.fonts.body};
-  font-weight: bold;
-  text-decoration: none;
-  line-height: 48px;
-
-  border-bottom: ${({theme}) => theme.sizes.borderWidth} solid transparent;
-
-  ${(props) => props.theme.mediaQueries.desktop} {
-    display: inline-block;
-    margin-left: 0.65rem;
-    padding: 0;
-    height: auto;
-
-    font-size: 14px;
-    line-height: 16px;
-  }
-
-  ${({theme, active}) =>
-    active && `border-bottom-color: ${theme.colors.primary};`};
-`;

--- a/app/components/templates/menu/menu.component.tsx
+++ b/app/components/templates/menu/menu.component.tsx
@@ -1,7 +1,5 @@
 import {FC} from 'react';
 
-import {Section} from '~/components/atoms/section';
-
 import {
   Grid,
   PrimaryContainer,
@@ -12,6 +10,7 @@ import configData from '../../../config.json';
 import useMediaQuery from '../../../hooks/use-media-query';
 import {HorizontalButton} from '../../atoms/horizontal-button';
 import {Hr} from '../../atoms/hr';
+import {Section} from '../../atoms/section';
 import {PromotionCard} from '../../molecules/promotion-card';
 import {Subtitle} from '../../molecules/subtitle';
 import {Carousel} from '../../organisms/carousel';

--- a/app/routes/$handle.tsx
+++ b/app/routes/$handle.tsx
@@ -4,7 +4,8 @@ import {Link, useLoaderData, useParams} from '@remix-run/react';
 import type {Node, Page, Product} from '@shopify/hydrogen/storefront-api-types';
 import {json, MetaFunction, type LoaderArgs} from '@shopify/remix-oxygen';
 
-import {NavBar, NavBarLink} from '~/components/organisms/navbar';
+import {CustomLink} from '~/components/atoms/link';
+import {NavBar} from '~/components/organisms/navbar';
 import {
   HeroBanner,
   MetafieldValue,
@@ -94,7 +95,7 @@ export async function loader({
 }
 
 // @ts-ignore
-const _Link = (props) => <NavBarLink {...props} as={Link} />;
+const _Link = (props) => <CustomLink {...props} as={Link} />;
 
 export function CatchBoundary() {
   const links = configData.navbar.links.map((link) => ({

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,5 +1,4 @@
 import {Link, useLoaderData} from '@remix-run/react';
-import {MenuItem} from '@shopify/hydrogen/storefront-api-types';
 
 import {CustomLink} from '~/components/atoms/link';
 import {Hero} from '~/components/organisms/hero';
@@ -10,8 +9,7 @@ import {Footer} from '~/components/templates/footer';
 import {Menu} from '~/components/templates/menu';
 import {Temple} from '~/components/templates/temple';
 import configData from '~/config.json';
-
-const hostname = 'perro.cafe';
+import {mapNavBarLinks} from '~/utils';
 
 // @ts-ignore
 export async function loader({context}) {
@@ -44,16 +42,7 @@ export default function Index() {
     };
   });
 
-  const links = menuItems.map((link: MenuItem) => {
-    const uri = new URL(link.url!);
-    const href = uri.hostname === hostname ? uri.pathname : link.url;
-
-    return {
-      label: link.title,
-      href,
-      ...(link.title === 'Inicio' && {active: 'true'}),
-    };
-  });
+  const links = mapNavBarLinks(menuItems, 'Inicio');
 
   const cultDescription = configData.cult.description;
   const cultImages = configData.cult.images;

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,4 +1,5 @@
 import {Link, useLoaderData} from '@remix-run/react';
+import {MenuItem} from '@shopify/hydrogen/storefront-api-types';
 
 import {Hero} from '~/components/organisms/hero';
 import {NavBar, NavBarLink} from '~/components/organisms/navbar';
@@ -8,6 +9,8 @@ import {Footer} from '~/components/templates/footer';
 import {Menu} from '~/components/templates/menu';
 import {Temple} from '~/components/templates/temple';
 import configData from '~/config.json';
+
+const hostname = 'perro.cafe';
 
 // @ts-ignore
 export async function loader({context}) {
@@ -20,6 +23,7 @@ const _Link = (props) => <NavBarLink {...props} as={Link} />;
 export default function Index() {
   // lmao this is a mess
   const {
+    menu: {items: menuItems},
     collections: {nodes},
   } = useLoaderData();
 
@@ -39,11 +43,16 @@ export default function Index() {
     };
   });
 
-  const links = configData.navbar.links.map((link) => ({
-    label: link.label,
-    href: link.link,
-    ...(link.label === 'Inicio' && {active: 'true'}),
-  }));
+  const links = menuItems.map((link: MenuItem) => {
+    const uri = new URL(link.url!);
+    const href = uri.hostname === hostname ? uri.pathname : link.url;
+
+    return {
+      label: link.title,
+      href,
+      ...(link.title === 'Inicio' && {active: 'true'}),
+    };
+  });
 
   const cultDescription = configData.cult.description;
   const cultImages = configData.cult.images;
@@ -65,6 +74,12 @@ export default function Index() {
 
 const COLLECTIONS_QUERY = `#graphql
   query FeaturedCollections {
+    menu(handle: "storefront-menu") {
+      items {
+        url
+        title
+      }
+    }
     collections(first: 1, query: "web-destacados") {
       nodes {
         products(first: 4) {

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,6 +1,7 @@
 import {Link, useLoaderData} from '@remix-run/react';
 import {MenuItem} from '@shopify/hydrogen/storefront-api-types';
 
+import {CustomLink} from '~/components/atoms/link';
 import {Hero} from '~/components/organisms/hero';
 import {NavBar, NavBarLink} from '~/components/organisms/navbar';
 import {Community} from '~/components/templates/community';
@@ -18,7 +19,7 @@ export async function loader({context}) {
 }
 
 // @ts-ignore
-const _Link = (props) => <NavBarLink {...props} as={Link} />;
+const _Link = (props) => <CustomLink {...props} as={Link} />;
 
 export default function Index() {
   // lmao this is a mess

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -3,7 +3,7 @@ import {MenuItem} from '@shopify/hydrogen/storefront-api-types';
 
 import {CustomLink} from '~/components/atoms/link';
 import {Hero} from '~/components/organisms/hero';
-import {NavBar, NavBarLink} from '~/components/organisms/navbar';
+import {NavBar} from '~/components/organisms/navbar';
 import {Community} from '~/components/templates/community';
 import {Cult} from '~/components/templates/cult';
 import {Footer} from '~/components/templates/footer';

--- a/app/routes/menu.tsx
+++ b/app/routes/menu.tsx
@@ -2,7 +2,8 @@ import {Link, useLoaderData} from '@remix-run/react';
 import type {Node} from '@shopify/hydrogen/storefront-api-types';
 import {json, type LoaderArgs} from '@shopify/remix-oxygen';
 
-import {NavBar, NavBarLink} from '~/components/organisms/navbar';
+import {CustomLink} from '~/components/atoms/link';
+import {NavBar} from '~/components/organisms/navbar';
 import {Footer} from '~/components/templates/footer';
 import {MenuPage} from '~/components/templates/menu-page';
 import configData from '~/config.json';
@@ -48,7 +49,7 @@ export async function loader({context: {storefront}}: LoaderArgs) {
 }
 
 // @ts-ignore
-const _Link = (props) => <NavBarLink {...props} as={Link} />;
+const _Link = (props) => <CustomLink {...props} as={Link} />;
 
 export default function Index() {
   const {collections} = useLoaderData<typeof loader>();

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1,5 +1,23 @@
 import {Theme} from '@emotion/react';
+import {MenuItem} from '@shopify/hydrogen/storefront-api-types';
+
+const hostname = 'perro.cafe';
 
 export const select =
   (fn: (_: Theme) => string | number) => (props: {theme: Theme}) =>
     fn(props.theme);
+
+export const mapNavBarLinks = (
+  menuItems: Array<MenuItem>,
+  pageHandle: string,
+) =>
+  menuItems.map((link) => {
+    const uri = new URL(link.url!);
+    const href = uri.hostname === hostname ? uri.pathname : link.url!;
+
+    return {
+      label: link.title,
+      href,
+      ...(link.title.match(new RegExp(pageHandle, 'gi')) && {active: 'true'}),
+    };
+  });


### PR DESCRIPTION
## Describe your changes

This PR adds a new component: Link. Link is a component which renders either a regular `a` tag or a Remix Link depending on whether its URL is external. As we've seen before on the NavBar, for instance, Storybook is incompatible with Remix's Link. In order to fix this, `Link` requires as a prop the component that should be rendered when its URL is internal. I've also moved the NavBarLink component into `link.styles.tsx` and renamed it to `CustomLink`, in order to keep proper styling on the NavBar.

Regarding the way of telling if the link is external or not, we don't think we're going to need a more complex implementation for now.

Also, this PR updates the existing queries on all three routes to also fetch the Navigation Menu. I decided to implement the function which maps the MenuItem Array into an array of objects as required by the NavBar's props.

## Task URL (Asana, Jira, etc...)

## What was done in this pull request

- [x] Added new component `<Link />`.
- [x] Updated GraphQL query for all routes.
- [x] Moved `NavBarLink` to `link.styles.tsx` as `CustomLink` to fit the NavBar's styling.
- [x] Moved the links mapping to `utils.ts` as it was being used by all routes with minor adjustments.
- [x] Fixed some import statements that were also conflicting with Storybook.

## Demo / Screenshot / Video

Can't provide video but [here's](https://rfnvqz7fr-3a3ad3a7297dea854149.myshopify.dev/) the preview.
