### PR TITLE
PromotionCards title

### DIFF
--- a/app/components/molecules/promotion-card/promotion-card.styles.tsx
+++ b/app/components/molecules/promotion-card/promotion-card.styles.tsx
@@ -11,8 +11,11 @@ export interface CardProps {
 export const Card = styled.div<CardProps>`
   border: ${select((theme) => theme.sizes.borderWidth)} solid
     ${select((theme) => theme.colors.black)};
-  display: inline-block;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 100%;
   position: relative;
+  overflow: hidden;
 
   ${({fullWidth}) => fullWidth && 'width: 100%'};
   ${({borderless}) => borderless && 'border: none'};
@@ -25,6 +28,7 @@ export const Card = styled.div<CardProps>`
     line-height: unset;
     height: unset;
     border-bottom: none;
+    overflow: hidden;
   }
 
   & p {
@@ -33,7 +37,12 @@ export const Card = styled.div<CardProps>`
     font-weight: bold;
     line-height: 2em;
     margin: 0;
+    padding: 0 0.5em;
     text-align: center;
+
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
   }
 `;
 

--- a/app/components/organisms/carousel/carousel.styles.tsx
+++ b/app/components/organisms/carousel/carousel.styles.tsx
@@ -64,4 +64,5 @@ export const CarouselNavigation = styled.div`
 export const StyledCarousel = styled.div`
   position: relative;
   width: fit-content;
+  max-width: 100%;
 `;

--- a/app/components/templates/menu/menu.styles.tsx
+++ b/app/components/templates/menu/menu.styles.tsx
@@ -20,7 +20,7 @@ export const PrimaryContainer = styled.div`
   }
 
   ${({theme}) => theme.mediaQueries.desktop} {
-    width: 50%;
+    width: 65%;
   }
 `;
 
@@ -32,6 +32,7 @@ export const Grid = styled.div`
 
 export const CarouselContainer = styled.div`
   margin: 0 auto;
+  max-width: 100%;
 `;
 
 export const MenuDescription = styled(Paragraph)``;

--- a/app/components/templates/menu/menu.styles.tsx
+++ b/app/components/templates/menu/menu.styles.tsx
@@ -20,7 +20,7 @@ export const PrimaryContainer = styled.div`
   }
 
   ${({theme}) => theme.mediaQueries.desktop} {
-    width: 65%;
+    width: 50%;
   }
 `;
 

--- a/app/components/templates/page-info/page-info.styles.tsx
+++ b/app/components/templates/page-info/page-info.styles.tsx
@@ -29,4 +29,5 @@ export const Products = styled.div`
 
 export const CarouselContainer = styled.div`
   margin: 0 auto;
+  max-width: 100%;
 `;


### PR DESCRIPTION
## Describe your changes

This PR applies `text-overflow:  ellipsis` to PromotionCards title. It also works on the Carousel's PromotionCards.

## Task URL (Asana, Jira, etc...)

## What was done in this pull request

- [x] Applied `text-overflow: ellipsis` to `<PromotionCard />` title.
- [x] Refactored some `<PromotionCard />` styles.
- [x] Refactored some containers' styles (`max-width`).
- [x] Applied a `max-width` to `<Carousel />`.

## Demo / Screenshot / Video

Here's the [preview](https://q98we1cch-3a3ad3a7297dea854149.myshopify.dev/).

![image](https://github.com/tepachelabs/perro-cafe-storefront/assets/39208827/fc188438-237e-4a8a-a89f-d16e20593e1f)

![image](https://github.com/tepachelabs/perro-cafe-storefront/assets/39208827/1baa21a6-0e70-40e4-bc3f-0f5b30db6cae)

![image](https://github.com/tepachelabs/perro-cafe-storefront/assets/39208827/51f1852f-f036-44c3-a98b-19049a33b5df)
